### PR TITLE
✨ NEW: Add table rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The only syntax where some checks are required is matching anonymous references 
 - only one kind of footnote (i.e. no symbol prefixes)
 - citation are turned into footnotes, with label prepended by `cite_prefix`
 - inline targets are not convertible (and so ignored)
+- If tables are not compatible with Markdown (single header row, no merged cells), then they will be wrapped in an `eval_rst`
 
 ## TODO
 
@@ -188,7 +189,6 @@ The only syntax where some checks are required is matching anonymous references 
 - custom functions for directive parsing
 - quote_block
 - substitution definitions
-- tables
 - definition lists
 - line block
 - literal block

--- a/rst_to_myst/parser.py
+++ b/rst_to_myst/parser.py
@@ -85,8 +85,13 @@ class ResolveListItems(Transform):
 class DirectiveNesting(Transform):
     def apply(self):
         for node in self.document.traverse(DirectiveNode):  # type: DirectiveNode
-            node["delimiter"] *= 3 + sum(
-                1 for _ in node.traverse(DirectiveNode, include_self=False)
+            # TODO this will overcount if multiple directives at same nesting depth
+            node["delimiter"] *= (
+                3
+                + sum(1 for _ in node.traverse(DirectiveNode, include_self=False))
+                # add an extra delimiter if the directive contains a table,
+                # because we wrap some in eval_rst directive
+                + (1 if sum(1 for _ in node.traverse(nodes.table)) else 0)
             )
 
 

--- a/tests/fixtures/ast.txt
+++ b/tests/fixtures/ast.txt
@@ -296,15 +296,6 @@ a
 .. [Ref] Book or article reference, URL or whatever.
 
 :fieldname a: Field content
-
-=====  =====  =======
-A      B      A and B
-=====  =====  =======
-False  False  False
-True   False  False
-False  True   False
-True   True   True
-=====  =====  =======
 .
 <document source="source">
     <target refid="a-link">
@@ -372,62 +363,143 @@ True   True   True
                     <field_body>
                         <paragraph>
                             Field content
-            <table>
-                <tgroup cols="3">
-                    <colspec colwidth="5">
-                    <colspec colwidth="5">
-                    <colspec colwidth="7">
-                    <thead>
-                        <row>
-                            <entry>
-                                <paragraph>
-                                    A
-                            <entry>
-                                <paragraph>
-                                    B
-                            <entry>
-                                <paragraph>
-                                    A and B
-                    <tbody>
-                        <row>
-                            <entry>
-                                <paragraph>
-                                    False
-                            <entry>
-                                <paragraph>
-                                    False
-                            <entry>
-                                <paragraph>
-                                    False
-                        <row>
-                            <entry>
-                                <paragraph>
-                                    True
-                            <entry>
-                                <paragraph>
-                                    False
-                            <entry>
-                                <paragraph>
-                                    False
-                        <row>
-                            <entry>
-                                <paragraph>
-                                    False
-                            <entry>
-                                <paragraph>
-                                    True
-                            <entry>
-                                <paragraph>
-                                    False
-                        <row>
-                            <entry>
-                                <paragraph>
-                                    True
-                            <entry>
-                                <paragraph>
-                                    True
-                            <entry>
-                                <paragraph>
-                                    True
+.
 
+tables-simple:
+.
+=====  =====  =======
+     AB1      C1
+------------  -------
+A2     B2     C2
+=====  =====  =======
+False  False  False
+True   False  False
+False  True   False
+True   True   True
+=====  =====  =======
+.
+<document source="source">
+    <table>
+        <tgroup cols="3">
+            <colspec colwidth="5">
+            <colspec colwidth="5">
+            <colspec colwidth="7">
+            <thead>
+                <row>
+                    <entry morecols="1">
+                    <entry>
+                <row>
+                    <entry>
+                        <paragraph>
+                            A2
+                    <entry>
+                        <paragraph>
+                            B2
+                    <entry>
+                        <paragraph>
+                            C2
+            <tbody>
+                <row>
+                    <entry>
+                        <paragraph>
+                            False
+                    <entry>
+                        <paragraph>
+                            False
+                    <entry>
+                        <paragraph>
+                            False
+                <row>
+                    <entry>
+                        <paragraph>
+                            True
+                    <entry>
+                        <paragraph>
+                            False
+                    <entry>
+                        <paragraph>
+                            False
+                <row>
+                    <entry>
+                        <paragraph>
+                            False
+                    <entry>
+                        <paragraph>
+                            True
+                    <entry>
+                        <paragraph>
+                            False
+                <row>
+                    <entry>
+                        <paragraph>
+                            True
+                    <entry>
+                        <paragraph>
+                            True
+                    <entry>
+                        <paragraph>
+                            True
+
+.
+
+tables-grid:
+.
++------------------------+------------+----------+----------+
+| Header row, column 1   | Header 2   | Header 3 | Header 4 |
+| (header rows optional) |            |          |          |
++========================+============+==========+==========+
+| body row 1, column 1   | col 1,2    | col 1,3  | col 1,4  |
++------------------------+------------+----------+----------+
+| body row 2             | col 2,2    | col 2,3  | col 2,4  |
++------------------------+------------+----------+----------+
+.
+<document source="source">
+    <table>
+        <tgroup cols="4">
+            <colspec colwidth="24">
+            <colspec colwidth="12">
+            <colspec colwidth="10">
+            <colspec colwidth="10">
+            <thead>
+                <row>
+                    <entry>
+                        <paragraph>
+                            Header row, column 1
+                            (header rows optional)
+                    <entry>
+                        <paragraph>
+                            Header 2
+                    <entry>
+                        <paragraph>
+                            Header 3
+                    <entry>
+                        <paragraph>
+                            Header 4
+            <tbody>
+                <row>
+                    <entry>
+                        <paragraph>
+                            body row 1, column 1
+                    <entry>
+                        <paragraph>
+                            col 1,2
+                    <entry>
+                        <paragraph>
+                            col 1,3
+                    <entry>
+                        <paragraph>
+                            col 1,4
+                <row>
+                    <entry>
+                        <paragraph>
+                            body row 2
+                    <entry>
+                        <paragraph>
+                            col 2,2
+                    <entry>
+                        <paragraph>
+                            col 2,3
+                    <entry>
+                        <paragraph>
+                            col 2,4
 .

--- a/tests/fixtures/render.txt
+++ b/tests/fixtures/render.txt
@@ -173,3 +173,53 @@ a
 
    5. x
 .
+
+tables-simple:
+.
+=====  =====  =======
+`a`_   B      A and B
+=====  =====  =======
+False  False  False
+True   False  False
+False  True   False
+True   True   `a`_
+=====  =====  =======
+
+para
+.
+| [a](a) | B     | A and B |
+| ------ | ----- | ------- |
+| False  | False | False   |
+| True   | False | False   |
+| False  | True  | False   |
+| True   | True  | [a](a)  |
+
+para
+.
+
+tables-grid:
+.
++------------------------+------------+----------+----------+
+| Header row, column 1   | Header 2   | Header 3 | Header 4 |
+| (header rows optional) |            |          |          |
++========================+============+==========+==========+
+| body row 1, column 1   | column 2   | column 3 | column 4 |
++------------------------+------------+----------+----------+
+| body row 2             | ...        | ...      |          |
++------------------------+------------+----------+----------+
+
+para
+.
+```{eval_rst}
++------------------------+------------+----------+----------+
+| Header row, column 1   | Header 2   | Header 3 | Header 4 |
+| (header rows optional) |            |          |          |
++========================+============+==========+==========+
+| body row 1, column 1   | column 2   | column 3 | column 4 |
++------------------------+------------+----------+----------+
+| body row 2             | ...        | ...      |          |
++------------------------+------------+----------+----------+
+```
+
+para
+.


### PR DESCRIPTION
If tables are compatible with Markdown (single header row, no merged cells), then they will be converted to Markdown, otherwise they are wrapped in an `eval_rst` directive.
