### PR TITLE
🐛 FIX: Unprocessed directive content

### DIFF
--- a/rst_to_myst/markdownit.py
+++ b/rst_to_myst/markdownit.py
@@ -200,6 +200,10 @@ class MarkdownItRenderer(nodes.GenericNodeVisitor):
         self.add_token("text", "", 0, content=node.astext())
         raise nodes.SkipNode
 
+    def visit_UnprocessedText(self, node):
+        self.add_token("unprocessed", "", 0, content=node.astext())
+        raise nodes.SkipNode
+
     def visit_emphasis(self, node):
         self.add_token("em_open", "em", 1, markup="*")
 

--- a/rst_to_myst/mdformat_render.py
+++ b/rst_to_myst/mdformat_render.py
@@ -12,6 +12,11 @@ from .parser import to_docutils_ast
 from .utils import yaml_dump
 
 
+def _unprocessed_render(node: RenderTreeNode, context: RenderContext) -> str:
+    """Text that should not be processed in any way (e.g. escaping characters)."""
+    return node.content
+
+
 def _front_matter_tokens_render(node: RenderTreeNode, context: RenderContext) -> str:
     """Special render for front-matter whose values also need to be rendered."""
     dct = {}
@@ -95,6 +100,7 @@ def _directive_render(node: RenderTreeNode, context: RenderContext) -> str:
 
 class AdditionalRenderers:
     RENDERERS = {
+        "unprocessed": _unprocessed_render,
         "front_matter_tokens": _front_matter_tokens_render,
         "substitution_block": _sub_renderer,
         "substitution_inline": _sub_renderer,

--- a/rst_to_myst/nodes.py
+++ b/rst_to_myst/nodes.py
@@ -3,6 +3,10 @@ from typing import Any, List, Tuple
 from docutils import nodes
 
 
+class UnprocessedText(nodes.Text):
+    """Text that should not be processed in any way (e.g. escaping characters)."""
+
+
 class EvalRstNode(nodes.Element):
     """Should contain a single ``Text`` node with the contents to wrap."""
 

--- a/rst_to_myst/states.py
+++ b/rst_to_myst/states.py
@@ -12,7 +12,13 @@ from docutils.utils import (
     extract_options,
 )
 
-from .nodes import ArgumentNode, ContentNode, DirectiveNode, EvalRstNode
+from .nodes import (
+    ArgumentNode,
+    ContentNode,
+    DirectiveNode,
+    EvalRstNode,
+    UnprocessedText,
+)
 
 # Alphanumerics with isolated internal [-._+:] chars (i.e. not 2 together):
 SIMPLENAME_RE = r"(?:(?!_)\w)+(?:[-._+:](?:(?!_)\w)+)*"
@@ -176,7 +182,7 @@ class ExplicitMixin:
                 # TODO report messages?
                 argument_node.extend(textnodes)
             else:
-                argument_node += nodes.Text(" ".join(arg_block))
+                argument_node += UnprocessedText(" ".join(arg_block))
 
         if directive_class.has_content:
             content_node = ContentNode()
@@ -189,7 +195,7 @@ class ExplicitMixin:
                     match_titles="titles" in conversion,
                 )
             else:
-                content_node += nodes.Text("\n".join(content or []))
+                content_node += UnprocessedText("\n".join(content or []))
 
         return [directive_node], blank_finish
 
@@ -202,7 +208,7 @@ class ExplicitMixin:
         if not block_text.startswith(".. "):
             # substitution definition directives
             block_text = ".. " + block_text
-        node += nodes.Text(block_text)
+        node += UnprocessedText(block_text)
         return [node], blank_finish
 
     def parse_directive_match(self, match):

--- a/tests/fixtures/render_extra.txt
+++ b/tests/fixtures/render_extra.txt
@@ -440,3 +440,23 @@ Revision: \$Revision\$
 
 # reStructuredText Directives
 .
+
+math-directives
+.
+.. math::
+   :label: poisson-ratio
+
+   \begin{aligned}
+   \lambda &= \frac{E \nu}{(1 + \nu)(1 - 2 \nu)} \\
+   \mu &= \frac{E}{2(1 + \nu)}
+   \end{aligned}.
+.
+```{math}
+:label: poisson-ratio
+
+\begin{aligned}
+\lambda &= \frac{E \nu}{(1 + \nu)(1 - 2 \nu)} \\
+\mu &= \frac{E}{2(1 + \nu)}
+\end{aligned}.
+```
+.

--- a/tests/test_texts/test_texts_theming_.md
+++ b/tests/test_texts/test_texts_theming_.md
@@ -1,34 +1,34 @@
 ---
 substitutions:
   agogo: |-
-    ```{image} /\_static/themes/agogo.png
+    ```{image} /_static/themes/agogo.png
     ```
   alabaster: |-
-    ```{image} /\_static/themes/alabaster.png
+    ```{image} /_static/themes/alabaster.png
     ```
   bizstyle: |-
-    ```{image} /\_static/themes/bizstyle.png
+    ```{image} /_static/themes/bizstyle.png
     ```
   classic: |-
-    ```{image} /\_static/themes/classic.png
+    ```{image} /_static/themes/classic.png
     ```
   haiku: |-
-    ```{image} /\_static/themes/haiku.png
+    ```{image} /_static/themes/haiku.png
     ```
   nature: |-
-    ```{image} /\_static/themes/nature.png
+    ```{image} /_static/themes/nature.png
     ```
   pyramid: |-
-    ```{image} /\_static/themes/pyramid.png
+    ```{image} /_static/themes/pyramid.png
     ```
   scrolls: |-
-    ```{image} /\_static/themes/scrolls.png
+    ```{image} /_static/themes/scrolls.png
     ```
   sphinxdoc: |-
-    ```{image} /\_static/themes/sphinxdoc.png
+    ```{image} /_static/themes/sphinxdoc.png
     ```
   traditional: |-
-    ```{image} /\_static/themes/traditional.png
+    ```{image} /_static/themes/traditional.png
     ```
 ---
 


### PR DESCRIPTION
Ensure non-Markdown directive arguments/content is not processed as text, e.g. by escaping certain characters.