### PR TITLE
✨ NEW: Convert math directives to dollar-math

### DIFF
--- a/rst_to_myst/cli.py
+++ b/rst_to_myst/cli.py
@@ -175,7 +175,7 @@ OPT_DOLLAR_MATH = click.option(
     "--dollar-math/--no-dollar-math",
     default=True,
     show_default=True,
-    help="Convert math roles to dollar delimited math",
+    help="Convert math (where possible) to dollar-delimited math",
 )
 
 

--- a/rst_to_myst/markdownit.py
+++ b/rst_to_myst/markdownit.py
@@ -629,6 +629,33 @@ class MarkdownItRenderer(nodes.GenericNodeVisitor):
                 info=argument.astext().strip(),
             )
             raise nodes.SkipNode
+        elif (
+            (
+                node["name"] == "math"
+                or node["module"] == "docutils.parsers.rst.directives.body.MathBlock"
+            )
+            and self.dollar_math
+            and (
+                not node["options_list"]
+                or (
+                    len(node["options_list"]) == 1
+                    and node["options_list"][0][0] == "label"
+                )
+            )
+            and len(node.children) == 2
+            and node.children[0].astext().strip() == ""
+        ):
+            # special case where we use dollarmath
+            _, content = node.children
+            text = "\n" + content.astext().strip() + "\n"
+            if node["options_list"]:
+                label = node["options_list"][0][1]
+                self.add_token(
+                    "math_block_eqno", "math", 0, markup="$$", content=text, info=label
+                )
+            else:
+                self.add_token("math_block", "math", 0, markup="$$", content=text)
+            raise nodes.SkipNode
         else:
             self.add_token(
                 "directive_open",

--- a/rst_to_myst/mdformat_render.py
+++ b/rst_to_myst/mdformat_render.py
@@ -161,7 +161,11 @@ def get_myst_extensions(tokens: List[Token]) -> Set[str]:
                 extensions.add("substitution")
         elif token.type == "directive_open" and ":" in token.markup:
             extensions.add("colon_fence")
-        elif token.type == "math_inline" or token.type == "math_block":
+        elif (
+            token.type == "math_inline"
+            or token.type == "math_block"
+            or token.type == "math_block_eqno"
+        ):
             extensions.add("dollarmath")
         elif token.type == "dl_open":
             extensions.add("deflist")
@@ -212,7 +216,7 @@ def rst_to_myst(
     :param raise_on_warning: Raise exception on parsing warning
     :param consecutive_numbering: Apply consecutive numbering to ordered lists
     :param colon_fences: Use colon fences for directives with parsed content
-    :param dollar_math: Convert ``math`` roles to dollar delimited math
+    :param dollar_math: Convert math (where possible) to dollar-delimited math
 
     """
     document, warning_stream = to_docutils_ast(

--- a/tests/fixtures/render_extra.txt
+++ b/tests/fixtures/render_extra.txt
@@ -441,7 +441,24 @@ Revision: \$Revision\$
 # reStructuredText Directives
 .
 
-math-directives
+math-directive-no-options
+.
+.. math::
+
+   \begin{aligned}
+   \lambda &= \frac{E \nu}{(1 + \nu)(1 - 2 \nu)} \\
+   \mu &= \frac{E}{2(1 + \nu)}
+   \end{aligned}.
+.
+$$
+\begin{aligned}
+\lambda &= \frac{E \nu}{(1 + \nu)(1 - 2 \nu)} \\
+\mu &= \frac{E}{2(1 + \nu)}
+\end{aligned}.
+$$
+.
+
+math-directive-label
 .
 .. math::
    :label: poisson-ratio
@@ -451,8 +468,26 @@ math-directives
    \mu &= \frac{E}{2(1 + \nu)}
    \end{aligned}.
 .
+$$
+\begin{aligned}
+\lambda &= \frac{E \nu}{(1 + \nu)(1 - 2 \nu)} \\
+\mu &= \frac{E}{2(1 + \nu)}
+\end{aligned}.
+$$ (poisson-ratio)
+.
+
+math-directive-nowrap
+.
+.. math::
+   :nowrap:
+
+   \begin{aligned}
+   \lambda &= \frac{E \nu}{(1 + \nu)(1 - 2 \nu)} \\
+   \mu &= \frac{E}{2(1 + \nu)}
+   \end{aligned}.
+.
 ```{math}
-:label: poisson-ratio
+:nowrap: true
 
 \begin{aligned}
 \lambda &= \frac{E \nu}{(1 + \nu)(1 - 2 \nu)} \\


### PR DESCRIPTION
Where possible (when no options outside `label` are specified) math directives are converted to dollar-delimited math.