### PR TITLE
👌 IMPROVE: dollarmath with argument

### DIFF
--- a/rst_to_myst/markdownit.py
+++ b/rst_to_myst/markdownit.py
@@ -643,11 +643,14 @@ class MarkdownItRenderer(nodes.GenericNodeVisitor):
                 )
             )
             and len(node.children) == 2
-            and node.children[0].astext().strip() == ""
         ):
             # special case where we use dollarmath
-            _, content = node.children
-            text = "\n" + content.astext().strip() + "\n"
+            argument, content = node.children
+            text = ""
+            if argument.astext().strip():
+                text += "\n" + argument.astext().strip() + "\n"
+            if content.astext().strip():
+                text += "\n" + content.astext().strip() + "\n"
             if node["options_list"]:
                 label = node["options_list"][0][1]
                 self.add_token(

--- a/tests/fixtures/render_extra.txt
+++ b/tests/fixtures/render_extra.txt
@@ -495,3 +495,13 @@ math-directive-nowrap
 \end{aligned}.
 ```
 .
+
+math-directive-nospace
+.
+.. math::
+   \int_{\Omega} \nabla v \cdot \nabla u = 0, \forall v
+.
+$$
+\int_{\Omega} \nabla v \cdot \nabla u = 0, \forall v
+$$
+.


### PR DESCRIPTION
The formatting in case both argument and body is present is intended to be consistent with:

https://github.com/sphinx-doc/sphinx/blob/eda4b1cfc49cddfeb8d9ce3b0c495ebebb01fb6c/sphinx/directives/patches.py#L196-L198

This implements the fix suggested in https://github.com/executablebooks/rst-to-myst/issues/13#issuecomment-868894833