### PR TITLE
👌 IMPROVE: directives.yml (spelling & description)

### DIFF
--- a/rst_to_myst/data/directives.yml
+++ b/rst_to_myst/data/directives.yml
@@ -3,7 +3,7 @@
 # - "direct": convert directly to MyST directive, keeping original argument/content
 # - "parse_argument":  convert to MyST directive and convert the argument to Markdown
 # - "parse_content":  convert to MyST directive and convert the content to Markdown
-# - "parse_all":  convert to MyST directive and convert the content to Markdown
+# - "parse_all":  convert to MyST directive and convert the argument and content to Markdown
 
 # admonitions (docutils)
 docutils.parsers.rst.directives.admonitions.Admonition: parse_all
@@ -211,4 +211,4 @@ sphinx.domains.std.ProductionList: eval_rst
 
 # third-party directives
 sphinxcontrib.bibtex.directives.BibliographyDirective: direct
-sphinx_panels.dropdpwn.DropdownDirective: parse_all
+sphinx_panels.dropdown.DropdownDirective: parse_all


### PR DESCRIPTION
I believe this fixes @mbercx's issue in https://github.com/executablebooks/rst-to-myst/issues/14#issuecomment-841607698. Specifically, one can now run `rst2myst convert -e sphinx_panels input.rst` and get the desired
```
:::{dropdown} MyST $\pi$ markdown title
and content {eq}`important-equation`
:::
```