### PR TITLE
ENH: Add option to convert code to code-cell directives in md output

### DIFF
--- a/rst_to_myst/cli.py
+++ b/rst_to_myst/cli.py
@@ -177,6 +177,12 @@ OPT_DOLLAR_MATH = click.option(
     show_default=True,
     help="Convert math (where possible) to dollar-delimited math",
 )
+OPT_CODE_TO_CODE_CELL = click.option(
+    "--code-to-code-cell",
+    default=False,
+    show_default=True,
+    help="Convert code directives to code-cell directives",
+)
 
 
 @main.command("ast")
@@ -211,6 +217,7 @@ def ast(stream: TextIOWrapper, language: str, sphinx: bool, extensions, conversi
 @OPT_CITE_PREFIX
 @OPT_COLON_FENCES
 @OPT_DOLLAR_MATH
+@OPT_CODE_TO_CODE_CELL
 @OPT_CONVERSIONS
 @OPT_CONFIG
 def tokens(
@@ -223,6 +230,7 @@ def tokens(
     cite_prefix: str,
     colon_fences: bool,
     dollar_math: bool,
+    code_to_code_cell: bool,
     conversions,
 ):
     """Parse file / stdin (-) and print Markdown-It tokens."""
@@ -239,6 +247,7 @@ def tokens(
         cite_prefix=cite_prefix + "_",
         colon_fences=colon_fences,
         dollar_math=dollar_math,
+        code_to_code_cell=code_to_code_cell,
     )
     click.echo(yaml_dump([token.as_dict() for token in output.tokens]))
 

--- a/rst_to_myst/markdownit.py
+++ b/rst_to_myst/markdownit.py
@@ -25,6 +25,7 @@ class MarkdownItRenderer(nodes.GenericNodeVisitor):
         default_role: Optional[str] = None,
         colon_fences: bool = True,
         dollar_math: bool = True,
+        code_to_code_cell: bool = False,
     ):
         self._document = document
         self._warning_stream = warning_stream or StringIO()
@@ -35,6 +36,7 @@ class MarkdownItRenderer(nodes.GenericNodeVisitor):
         self.default_role = default_role
         self.colon_fences = colon_fences
         self.dollar_math = dollar_math
+        self.code_to_code_cell = code_to_code_cell
 
         self.reset_state()
 
@@ -86,6 +88,7 @@ class MarkdownItRenderer(nodes.GenericNodeVisitor):
             default_role=self.default_role,
             colon_fences=self.colon_fences,
             dollar_math=self.dollar_math,
+            code_to_code_cell=self.code_to_code_cell,
         )
         for node in nodes:
             node.walkabout(new_inst)
@@ -619,10 +622,15 @@ class MarkdownItRenderer(nodes.GenericNodeVisitor):
             and len(node.children) == 2
         ):
             # special case, where we can use standard Markdown fences
+            token_type = "fence"
+            directive_name = "code"
+            if self.code_to_code_cell:
+                token_type = "directive"
+                directive_name = "code-cell"
             argument, content = node.children
             self.add_token(
-                "fence",
-                "code",
+                token_type,
+                directive_name,
                 0,
                 content=content.astext() + "\n",
                 markup="```",

--- a/rst_to_myst/mdformat_render.py
+++ b/rst_to_myst/mdformat_render.py
@@ -197,6 +197,7 @@ def rst_to_myst(
     consecutive_numbering: bool = True,
     colon_fences: bool = True,
     dollar_math: bool = True,
+    code_to_code_cell: bool = False,
 ) -> ConvertedOutput:
     """Convert RST text to MyST Markdown text.
 
@@ -236,6 +237,7 @@ def rst_to_myst(
         default_role=default_role,
         colon_fences=colon_fences,
         dollar_math=dollar_math,
+        code_to_code_cell = code_to_code_cell,
     )
     output = token_renderer.to_tokens()
     myst_extension = get_myst_extensions(output.tokens)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,3 +82,25 @@ def test_convert(tmp_path: Path, file_regression):
         encoding="utf8",
         extension=".md",
     )
+
+def test_convert_code_to_code_cell(tmp_path: Path, file_regression):
+    tmp_path.joinpath("test-code-cell.rst").write_text(
+        "head\n====\n\n.. code::\n\n\timport numpy as np", encoding="utf8"
+    )
+    tmp_path.joinpath("config-code-cell.yaml").write_text("code_to_code_cell: true\n", encoding="utf8")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.convert,
+        [
+            "--config",
+            str(tmp_path.joinpath("config-code-cell.yaml")),
+            str(tmp_path.joinpath("test-code-cell.rst")),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert tmp_path.joinpath("test-code-cell.md").exists()
+    file_regression.check(
+        tmp_path.joinpath("test-code-cell.md").read_text(encoding="utf8"),
+        encoding="utf8",
+        extension=".md",
+    )

--- a/tests/test_cli/test_convert_code_to_code_cell.md
+++ b/tests/test_cli/test_convert_code_to_code_cell.md
@@ -1,0 +1,5 @@
+# head
+
+```
+import numpy as np
+```


### PR DESCRIPTION
This PR adds the option to convert `code` in `rst` to `code-cell` in markdown for use with `jupyter-book` and enables the direct conversion to executable `code-cell` directives that are available in `myst`. 

This is enabled using:

```
--code-to-code-cell
```

in the `cli` or 

```
code_to_code_cell: true
```

in the `config.yaml`