### PR TITLE
🐛 FIX: RST tables `eval_rst` -> `eval-rst`

### DIFF
--- a/rst_to_myst/markdownit.py
+++ b/rst_to_myst/markdownit.py
@@ -408,7 +408,7 @@ class MarkdownItRenderer(nodes.GenericNodeVisitor):
             if not text.endswith("\n"):
                 text += "\n"
             self.add_token(
-                "fence", "code", 0, content=text, markup="```", info="{eval_rst}"
+                "fence", "code", 0, content=text, markup="```", info="{eval-rst}"
             )
             raise nodes.SkipNode
 

--- a/tests/fixtures/render.txt
+++ b/tests/fixtures/render.txt
@@ -326,7 +326,7 @@ X  Y
 C  D
 == ==
 .
-```{eval_rst}
+```{eval-rst}
 == ==
 A  B
 X  Y


### PR DESCRIPTION
closes #27