### PR TITLE
Relax dependency on click

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires=[
     "mdformat~=0.7.6",
     "mdformat-myst~=0.1.4",
     "mdformat-deflist~=0.1.0",
-    "click~=7.1"
+    "click>=7.1"
 ]
 
 [tool.flit.entrypoints."console_scripts"]


### PR DESCRIPTION
Current dependency prevents use of click 8 and that is causing lost of conflicts with other tools.