### PR TITLE
👌 IMPROVE: Cache directive data loading

### DIFF
--- a/rst_to_myst/parser.py
+++ b/rst_to_myst/parser.py
@@ -1,5 +1,6 @@
+from functools import lru_cache
 from io import StringIO
-from typing import Tuple
+from typing import Any, Dict, Tuple
 
 import yaml
 from docutils import nodes
@@ -127,6 +128,13 @@ class FrontMatter(Transform):
             candidate.replace_self(front_matter)
 
 
+@lru_cache
+def _load_directive_data() -> Dict[str, Any]:
+    return yaml.safe_load(
+        files(package_data).joinpath("directives.yml").read_text("utf8")
+    )
+
+
 def to_docutils_ast(
     text: str,
     uri: str = "source",
@@ -161,9 +169,7 @@ def to_docutils_ast(
     document.settings.namespace = namespace
 
     # get conversion lookup for directives
-    directive_data = yaml.safe_load(
-        files(package_data).joinpath("directives.yml").read_text("utf8")
-    )
+    directive_data = _load_directive_data()
     if conversions:
         directive_data.update(conversions)
     document.settings.directive_data = directive_data

--- a/rst_to_myst/parser.py
+++ b/rst_to_myst/parser.py
@@ -128,7 +128,7 @@ class FrontMatter(Transform):
             candidate.replace_self(front_matter)
 
 
-@lru_cache
+@lru_cache()
 def _load_directive_data() -> Dict[str, Any]:
     return yaml.safe_load(
         files(package_data).joinpath("directives.yml").read_text("utf8")


### PR DESCRIPTION
When repeatedly calling `to_docutils_ast` on relatively small `text`s without sphinx support (I'll deal with that in a later PR), the runtime cost is dominated by `yaml.safe_load`.

Looks like `directives.yml` isn't expected to change, so it should be safe to load it only once, and cache the result for future invocations.

I ran the following perf test on top of this PR (added an extra flag to `to_docutils_ast` that controlled clearing the `lru_cache`):

```
python -m fastero -s 'from rst_to_myst.parser import to_docutils_ast; docstring=\"This is *emphasized*.\"' -n cached 'to_docutils_ast(docstring, use_sphinx=False, cache_directives=True)' -n uncached 'to_docutils_ast(docstring, use_sphinx=False, cache_directives=False)'
```

![perf](https://user-images.githubusercontent.com/66740/187080292-369aae5c-5f78-41b4-b79b-f27cf667f534.svg)

