### PR TITLE
perf: cache ApplicationNamespaces

### DIFF
--- a/rst_to_myst/cli.py
+++ b/rst_to_myst/cli.py
@@ -126,7 +126,7 @@ def split_extension(ctx, param, value):
     if isinstance(value, list):
         # if reading from config
         return value
-    return [ext.strip() for ext in value.split(",")] if value else []
+    return tuple(ext.strip() for ext in value.split(",")) if value else ()
 
 
 OPT_EXTENSIONS = click.option(

--- a/rst_to_myst/namespace.py
+++ b/rst_to_myst/namespace.py
@@ -1,5 +1,6 @@
 import copy
 import threading
+from functools import lru_cache
 from importlib import import_module
 from inspect import getdoc
 from itertools import chain
@@ -176,6 +177,7 @@ class ApplicationNamespace:
         }
 
 
+@lru_cache
 def compile_namespace(
     extensions: Iterable[str] = (),
     use_sphinx: bool = True,

--- a/rst_to_myst/namespace.py
+++ b/rst_to_myst/namespace.py
@@ -177,7 +177,7 @@ class ApplicationNamespace:
         }
 
 
-@lru_cache
+@lru_cache()
 def compile_namespace(
     extensions: Iterable[str] = (),
     use_sphinx: bool = True,


### PR DESCRIPTION
Calling `to_docutils_ast` repeatedly results in calling `compile_namespace` every time, even if directives and roles don't change between invocations. `compile_namespace` is relatively expensive, especially when sphinx is involved. This commit memoizes `compile_namespace` for significant perf improvements.
