### PR TITLE
👌 IMPROVE: Add support for doctest_block nodes

### DIFF
--- a/rst_to_myst/markdownit.py
+++ b/rst_to_myst/markdownit.py
@@ -259,6 +259,9 @@ class MarkdownItRenderer(nodes.GenericNodeVisitor):
         self.add_token("code_block", "code", 0, content=text)
         raise nodes.SkipNode
 
+    def visit_doctest_block(self, node):
+        self.visit_literal_block(node)
+
     def visit_block_quote(self, node):
         self.add_token("blockquote_open", "blockquote", 1, markup=">")
 

--- a/rst_to_myst/markdownit.py
+++ b/rst_to_myst/markdownit.py
@@ -260,6 +260,7 @@ class MarkdownItRenderer(nodes.GenericNodeVisitor):
         raise nodes.SkipNode
 
     def visit_doctest_block(self, node):
+        self.warning("Treating doctest block as a literal block", node.line)
         self.visit_literal_block(node)
 
     def visit_block_quote(self, node):

--- a/rst_to_myst/markdownit.py
+++ b/rst_to_myst/markdownit.py
@@ -261,8 +261,21 @@ class MarkdownItRenderer(nodes.GenericNodeVisitor):
         raise nodes.SkipNode
 
     def visit_doctest_block(self, node):
-        self.warning("Treating doctest block as a literal block", node.line)
-        self.visit_literal_block(node)
+        # https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#doctest-blocks
+        # https://pygments.org/docs/lexers/#pygments.lexers.python.PythonConsoleLexer
+        self.warning("Treating doctest block as pycon literal block", node.line)
+        text = node.astext()
+        if not text.endswith("\n"):
+            text += "\n"
+        self.add_token(
+            "fence",
+            "code",
+            0,
+            content=text,
+            markup="```",
+            info="pycon",
+        )
+        raise nodes.SkipNode
 
     def visit_block_quote(self, node):
         self.add_token("blockquote_open", "blockquote", 1, markup=">")

--- a/tests/fixtures/render.txt
+++ b/tests/fixtures/render.txt
@@ -41,19 +41,23 @@ literal text
 normal text
 .
 
-doctest block:
+doctest block [EXPECT_WARNING]:
 .
-::
+This is an ordinary paragraph.
 
->>> some text
+>>> print 'this is a Doctest block'
+this is a Doctest block
 
-normal text
+Another paragraph
 .
-```
->>> some text
+This is an ordinary paragraph.
+
+```pycon
+>>> print 'this is a Doctest block'
+this is a Doctest block
 ```
 
-normal text
+Another paragraph
 .
 
 block quotes

--- a/tests/fixtures/render.txt
+++ b/tests/fixtures/render.txt
@@ -41,6 +41,21 @@ literal text
 normal text
 .
 
+doctest block:
+.
+::
+
+>>> some text
+
+normal text
+.
+```
+>>> some text
+```
+
+normal text
+.
+
 block quotes
 .
 a

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -32,7 +32,10 @@ def test_ast(line, title, rst, expected):
 def test_render(line, title, rst, expected):
     output = rst_to_myst(rst)
     try:
-        assert output.warning_stream.getvalue() == ""
+        if "EXPECT_WARNING" not in title:
+            assert output.warning_stream.getvalue() == ""
+        else:
+            assert output.warning_stream.getvalue() != ""
         assert output.text.rstrip() == expected.rstrip()
     except AssertionError:
         print(output.text)


### PR DESCRIPTION
Currently these are treated like a paragraph. Treating them like a `literal_block` is better.