### PR TITLE
docs: replace "dropdpwn" with "dropdown"

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -46,7 +46,7 @@ consecutive_numbering: true
 colon_fences: true
 dollar_math: true
 conversions:
-    sphinx_panels.dropdpwn.DropdownDirective: parse_all
+    sphinx_panels.dropdown.DropdownDirective: parse_all
 ```
 
 ```{toctree}

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -75,7 +75,7 @@ consecutive_numbering: true
 colon_fences: true
 dollar_math: true
 conversions:
-  sphinx_panels.dropdpwn.DropdownDirective: parse_all
+  sphinx_panels.dropdown.DropdownDirective: parse_all
 ```
 
 ### Directive conversion


### PR DESCRIPTION
The fully-qualified name for the
`sphinx_panels.dropdown.DropdownDirective` is misspelled in the project documentation. This pull request corrects that misspelling.

Signed-off-by: Geoffrey M Oxberry <goxberry@gmail.com>