### PR TITLE
🔧 flake8: fix pre-commit errors

### DIFF
--- a/rst_to_myst/states.py
+++ b/rst_to_myst/states.py
@@ -145,7 +145,7 @@ class ExplicitMixin:
         ]:
             if conversion and conversion != "eval_rst":
                 self.reporter.warning(
-                    f'Unknown conversion type "{conversion}"',
+                    f"Unknown conversion type {conversion!r}",
                     nodes.literal_block(block_text, block_text),
                     line=lineno,
                 )
@@ -160,7 +160,7 @@ class ExplicitMixin:
             ) = self.parse_directive_block(indented, line_offset, directive_class)
         except states.MarkupError as error:
             self.reporter.warning(
-                f'Error in "{type_name}" directive parse:\n{" ".join(error.args)}',
+                f'Error in {type_name!r} directive parse:\n{" ".join(error.args)}',
                 nodes.literal_block(block_text, block_text),
                 line=lineno,
             )
@@ -347,7 +347,7 @@ class ExplicitMixin:
         substitution_node.line = srcline
         if not block:
             raise states.MarkupError(
-                f'Substitution definition "{subname}" missing contents: {src}:{srcline}'
+                f"Substitution definition {subname!r} missing contents: {src}:{srcline}"
             )
         block[0] = block[0].strip()
         substitution_node["names"].append(nodes.whitespace_normalize_name(subname))


### PR DESCRIPTION
On Python 3.9.2 with the virtual environment

```
cachetools==5.2.1
certifi==2022.12.7
cfgv==3.3.1
chardet==5.1.0
charset-normalizer==3.0.1
colorama==0.4.6
distlib==0.3.6
docutils==0.19
filelock==3.9.0
flit==3.8.0
flit_core==3.8.0
identify==2.5.13
idna==3.4
nodeenv==1.7.0
packaging==23.0
pip==22.3.1
pkg_resources==0.0.0
platformdirs==2.6.2
pluggy==1.0.0
pre-commit==2.21.0
pyproject_api==1.4.0
PyYAML==6.0
requests==2.28.2
setuptools==65.7.0
tomli==2.0.1
tomli_w==1.0.0
tox==4.2.8
urllib3==1.26.14
virtualenv==20.17.1
wheel==0.38.4
```

running
```shell
pre-commit install --install-hooks
pre-commit run --all
```

in the project root results in the output
```console
(.venv) goxberry@penguin:~/repos/github.com/executable-books/rst-to-myst$ pre-commit run --all
fix end of files.........................................................Passed
mixed line ending........................................................Passed
trim trailing whitespace.................................................Passed
check yaml...............................................................Passed
check toml...............................................................Passed
check blanket noqa.......................................................Passed
isort....................................................................Passed
black....................................................................Passed
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

rst_to_myst/states.py:148:21: B028 'conversion' is manually surrounded by quotes, consider using the `!r` conversion flag.
rst_to_myst/states.py:163:17: B028 'type_name' is manually surrounded by quotes, consider using the `!r` conversion flag.
rst_to_myst/states.py:350:17: B028 'subname' is manually surrounded by quotes, consider using the `!r` conversion flag.
```

This commit remediates those errors by adding the `!r` conversion flag to the brace expressions in the f-strings of the lines referenced in the output above.

An alternative fix would be to add `B028` to the `extend-ignore` setting in the `[flake8]` section of `tox.ini` in the project root directory.

It appears that this changeset (or the alternative discussed above) must be merged in order to be able to merge #50 without CI errors.

Signed-off-by: Geoffrey M Oxberry <goxberry@gmail.com>