### PR TITLE
maintain: upgrade deprecated Node 12 GitHub actions to Node 16 actions (companion to PR #53)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: "3.8"
 
@@ -67,13 +67,16 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v3
+
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: "3.8"
+
     - name: install flit
       run: |
         pip install flit~=3.0
+
     - name: Build and publish
       run: |
         flit publish

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
         python-version: "3.8"
+
     - uses: pre-commit/action@v2.0.0
 
   tests:
@@ -29,7 +31,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
@@ -64,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         python-version: "3.8"
 
-    - uses: pre-commit/action@v2.0.0
+    - uses: pre-commit/action@v3.0.0
 
   tests:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Some of the GitHub Actions used in the project CI workflow use Node 12 and are deprecated, as dicsussed in PR #53, which adds a Dependabot configuration to automatically scan the project CI configuration and submit pull requests that upgrade the GitHub Actions used by the project.

This pull request is a companion pull request to PR #53 that upgrades the GitHub Actions used in project CI to Node 16 actions, and will avoid having to wait for Dependabot to submit PRs that will make similar changes.