### PR TITLE
🐛 FIX: CLI option callbacks with --config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,11 +37,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Installation (deps and package)
-      # we install with flit --pth-file,
-      # so that coverage will be recorded up for the module
       run: |
-        pip install flit
-        flit install --deps=production --extras=test,sphinx --pth-file
+        pip install --upgrade pip
+        pip install -e .[test,sphinx]
 
     - name: Run pytest
       run: |

--- a/rst_to_myst/cli.py
+++ b/rst_to_myst/cli.py
@@ -94,6 +94,7 @@ OPT_CONVERSIONS = click.option(
     "--conversions",
     "-c",
     default=None,
+    type=click.types.UNPROCESSED,
     callback=read_conversions,
     metavar="PATH",
     help="YAML file mapping directives -> conversions",
@@ -132,6 +133,7 @@ def split_extension(ctx, param, value):
 OPT_EXTENSIONS = click.option(
     "--extensions",
     "-e",
+    type=click.types.UNPROCESSED,
     callback=split_extension,
     help="A comma-separated list of sphinx extensions to load.",
 )

--- a/rst_to_myst/parser.py
+++ b/rst_to_myst/parser.py
@@ -191,7 +191,7 @@ def to_docutils_ast(
     # get conversion lookup for directives
     directive_data = _load_directive_data()
     if conversions:
-        directive_data.update(conversions)
+        directive_data = {**directive_data, **conversions}
     document.settings.directive_data = directive_data
 
     # whether to treat initial field list as front matter

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from textwrap import dedent
 
 from click.testing import CliRunner
 
@@ -63,9 +64,31 @@ def test_stream():
 
 def test_convert(tmp_path: Path, file_regression):
     tmp_path.joinpath("test.rst").write_text(
-        "head\n====\n\ncontent `a`\n", encoding="utf8"
+        dedent(
+            """\
+        head
+        ====
+
+        content `a`
+
+        .. note:: `c`
+        ```
+        """
+        ),
+        encoding="utf8",
     )
-    tmp_path.joinpath("config.yaml").write_text("default_role: math\n", encoding="utf8")
+    tmp_path.joinpath("config.yaml").write_text(
+        dedent(
+            """\
+        default_role: math
+        sphinx: true
+        extensions: [sphinx.ext.intersphinx]
+        conversions:
+            docutils.parsers.rst.directives.admonitions.Note: direct
+        """
+        ),
+        encoding="utf8",
+    )
     runner = CliRunner()
     result = runner.invoke(
         cli.convert,

--- a/tests/test_cli/test_convert.md
+++ b/tests/test_cli/test_convert.md
@@ -1,3 +1,7 @@
 # head
 
 content $a$
+
+```{note}
+`c`
+```

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 envlist = py38
-isolated_build = True
+
+[testenv]
+usedevelop = true
 
 [testenv:py{37,38,39,310,311}]
 deps =


### PR DESCRIPTION
These option value should be unprocessed.
This also fixes a bug with the directive data caching.