### PR TITLE
`pre-commit autoupdate && pre-commit run --all-files`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - uses: pre-commit/action@v3.0.0
 
   tests:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v5.0.0
   hooks:
   - id: end-of-file-fixer
   - id: mixed-line-ending
@@ -16,15 +16,15 @@ repos:
   hooks:
   - id: python-check-blanket-noqa
 - repo: https://github.com/PyCQA/isort
-  rev: 5.12.0
+  rev: 5.13.2
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
-  rev: 23.7.0
+  rev: 24.10.0
   hooks:
   - id: black
 - repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
+  rev: 7.1.1
   hooks:
   - id: flake8
     additional_dependencies:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,6 +4,7 @@ It is recommended to use tox to run the build (see tox.ini):
 `tox -e docs-clean` and `tox -e docs-update`,
 or directly: `sphinx-build -n -W --keep-going docs/source docs/_build`
 """
+
 from rst_to_myst import __version__
 
 project = "RST-to-MyST"

--- a/rst_to_myst/__init__.py
+++ b/rst_to_myst/__init__.py
@@ -1,4 +1,5 @@
 """Convert RST to MyST-Markdown."""
+
 from .mdformat_render import rst_to_myst
 from .namespace import compile_namespace
 from .parser import to_docutils_ast

--- a/rst_to_myst/inliner.py
+++ b/rst_to_myst/inliner.py
@@ -41,6 +41,7 @@ hyperlink uri   http://a.net/
 embedded uri    `uri <a.org>`_
 --------------- --------------- --------------------------------------------------------
 """
+
 import re
 from typing import Any, Callable, List, Match, Pattern, Tuple
 

--- a/rst_to_myst/markdownit.py
+++ b/rst_to_myst/markdownit.py
@@ -1,4 +1,5 @@
 """Convert to markdown-it tokens, which can then be rendered by mdformat."""
+
 from io import StringIO
 from textwrap import indent
 from typing import IO, Any, Dict, List, NamedTuple, Optional, Tuple

--- a/rst_to_myst/states.py
+++ b/rst_to_myst/states.py
@@ -1,4 +1,5 @@
 """docutils states."""
+
 import re
 from typing import List, Optional
 
@@ -121,9 +122,9 @@ class ExplicitMixin:
         # directive_class, messages = directives.directive(
         #     type_name, self.memo.language, self.document
         # )
-        directive_class: Optional[
-            Directive
-        ] = self.document.settings.namespace.get_directive(type_name)
+        directive_class: Optional[Directive] = (
+            self.document.settings.namespace.get_directive(type_name)
+        )
 
         # default to eval rst
         if directive_class is None:


### PR DESCRIPTION
Fixes #75 
* #75

% `pre-commit autoupdate`
```
[https://github.com/pre-commit/pre-commit-hooks] updating v4.4.0 -> v5.0.0
[https://github.com/pre-commit/pygrep-hooks] already up to date!
[https://github.com/PyCQA/isort] updating 5.12.0 -> 5.13.2
[https://github.com/psf/black] updating 23.7.0 -> 24.10.0
[https://github.com/PyCQA/flake8] updating 6.0.0 -> 7.1.1
```
% `pre-commit run --all-files`
```
fix end of files.........................................................Passed
mixed line ending........................................................Passed
trim trailing whitespace.................................................Passed
check yaml...............................................................Passed
check toml...............................................................Passed
check blanket noqa.......................................................Passed
isort....................................................................Passed
black....................................................................Failed
- hook id: black
- files were modified by this hook

reformatted rst_to_myst/__init__.py
reformatted docs/source/conf.py
reformatted rst_to_myst/states.py
reformatted rst_to_myst/markdownit.py
reformatted rst_to_myst/inliner.py

All done! ✨ 🍰 ✨
5 files reformatted, 10 files left unchanged.

flake8...................................................................Passed
```