### PR TITLE
Fix the failing Read the Docs builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.x"
+    python: 3.12
 
 python:
   version: 3

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,12 +4,11 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
 
 python:
-  # version: 3
   install:
       - method: pip
         path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,10 +6,10 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: 3.12
+    python: "3.12"
 
 python:
-  version: 3
+  # version: 3
   install:
       - method: pip
         path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,12 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
 version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
 
 python:
   version: 3

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,8 +5,8 @@ version: 2
 
 build:
   os: ubuntu-22.04
-  # tools:
-  #  python: "3.12"
+  tools:
+    python: "3.x"
 
 python:
   version: 3

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,8 +5,8 @@ version: 2
 
 build:
   os: ubuntu-22.04
-  tools:
-    python: "3.12"
+  # tools:
+  #  python: "3.12"
 
 python:
   version: 3


### PR DESCRIPTION
The builds are failing... https://readthedocs.org/projects/rst-to-myst/builds

__-->__ ✅  docs/readthedocs.org:rst-to-myst — Read the Docs build succeeded! 

Read the Docs configuration file for Sphinx projects
See https://docs.readthedocs.io/en/stable/config-file/v2.html for details