### PR TITLE
[FIX] strip NUL padding from token content before rendering (CJK grid tables) (#95)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 
+sphinx:
+  configuration: /source/conf.py
+
 build:
   os: ubuntu-22.04
   tools:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,4 +15,4 @@ python:
 sphinx:
   builder: html
   fail_on_warning: true
-  configuration: /source/conf.py
+  configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,5 @@
 version: 2
 
-sphinx:
-  configuration: /source/conf.py
-
 build:
   os: ubuntu-22.04
   tools:
@@ -18,3 +15,4 @@ python:
 sphinx:
   builder: html
   fail_on_warning: true
+  configuration: /source/conf.py

--- a/rst_to_myst/mdformat_render.py
+++ b/rst_to_myst/mdformat_render.py
@@ -99,6 +99,19 @@ def _directive_render(node: RenderTreeNode, context: RenderContext) -> str:
     return f"{fence_str}{{{name}}}{info_str}\n{option_block}{code_block}{fence_str}"
 
 
+def _strip_nuls_in_tokens(tokens: list[Token]):
+    """Recursively remove NUL padding (\x00) from token contents."""
+    if not tokens:
+        return
+    for token in tokens:
+        if isinstance(getattr(token, "content", None), str) and "\x00" in token.content:
+            # Docutils table parser may insert '\x00' for East Asian double-width padding.
+            # These must never reach mdformat/commonmark renderers.
+            token.content = token.content.replace("\x00", "")
+    if getattr(token, "children", None):
+        _strip_nuls_in_tokens(token.children)
+
+
 class AdditionalRenderers:
     RENDERERS = {
         "unprocessed": _unprocessed_render,
@@ -134,6 +147,8 @@ def from_tokens(
         warning_handler.setLevel(logging.WARNING)
         LOGGER.addHandler(warning_handler)
     try:
+        _strip_nuls_in_tokens(output.tokens)
+
         # mdformat outputs only used reference definitions during 'finalize'
         # instead we want to output all parsed reference definitions
         text = md_renderer.render(output.tokens, options, output.env, finalize=False)


### PR DESCRIPTION
## Issue
https://github.com/executablebooks/rst-to-myst/issues/95

## Summary
This PR fixes a crash when converting an `.rst` file that contains a grid table with double-width characters (e.g. Japanese). 

**Root cause**: Docutils pads double-width characters during table parsing by temporarily inserting a NUL (\x00) sentinel. In the RST→MyST path (Docutils AST → markdown-it tokens → renderer), that NUL can remain in token content and reach the Markdown renderer, which then errors out.

**Fix**: Right before rendering, recursively strip \x00 from token content. This keeps the renderer from ever seeing embedded NULs. The change is minimal and localized to the rendering step.

## Minimal Reproduction
`test.rst`

```rst
+-------+-------+
|  列A  |  列B  |
+-------+-------+
|  あい |  かき |
+-------+-------+
```
#### Before
```console
$rst2myst convert test.md
test.rst -> test.md
FAILED:
null bytes should be removed by now

FINISHED ALL! (extensions: [])
```

#### After
```console
$rst2myst convert test.md
test.md -> test.md
CONVERTED (extensions: [])

FINISHED ALL! (extensions: [])
```

## test
<img width="681" height="56" alt="image" src="https://github.com/user-attachments/assets/9543393d-a051-4c54-bd84-e1bfb5abd05f" />

## pre-commit result
<img width="739" height="144" alt="image" src="https://github.com/user-attachments/assets/76c2b18c-9674-4198-a51d-b482a05977a7" />
