### PR TITLE
Update Markdown dependencies for MyST Parser 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,15 @@ classifiers = [
 readme = "README.md"
 keywords = ["restructuredtext","markdown", "myst"]
 
-requires-python=">=3.9"
+requires-python=">=3.10"
 dependencies=[
     "docutils>=0.17,<0.22",
     "pyyaml",
-    "markdown-it-py~=2.0",
-    "mdformat~=0.7.16",
-    "mdformat-myst~=0.1.5",
-    "mdformat-deflist~=0.1.2",
+    "markdown-it-py>=3,<4",
+    "mdit-py-plugins>=0.4,<0.5",
+    "mdformat>=0.7.22,<0.8",
+    "mdformat-myst>=0.3,<0.4",
+    "mdformat-deflist>=0.1.3,<0.2",
     "click>=7.1,<9"
 ]
 
@@ -38,7 +39,7 @@ Documentation = "https://rst-to-myst.readthedocs.io"
 rst2myst = "rst_to_myst.cli:main"
 
 [project.optional-dependencies]
-sphinx = ["sphinx>=5,<7"]
+sphinx = ["sphinx>=5,<8"]
 test = [
     "pytest~=8.3",
     "coverage",

--- a/rst_to_myst/cli.py
+++ b/rst_to_myst/cli.py
@@ -1,7 +1,6 @@
 from collections.abc import Mapping
 from io import TextIOWrapper
 from pathlib import Path
-from typing import Optional
 
 import click
 import yaml
@@ -222,7 +221,7 @@ def tokens(
     sphinx: bool,
     extensions: list[str],
     default_domain: str,
-    default_role: Optional[str],
+    default_role: str | None,
     cite_prefix: str,
     colon_fences: bool,
     dollar_math: bool,
@@ -265,7 +264,7 @@ def stream(
     sphinx: bool,
     extensions: list[str],
     default_domain: str,
-    default_role: Optional[str],
+    default_role: str | None,
     cite_prefix: str,
     consecutive_numbering: bool,
     colon_fences: bool,
@@ -319,7 +318,7 @@ def convert(
     sphinx: bool,
     extensions: list[str],
     default_domain: str,
-    default_role: Optional[str],
+    default_role: str | None,
     cite_prefix: str,
     consecutive_numbering: bool,
     colon_fences: bool,

--- a/rst_to_myst/inliner.py
+++ b/rst_to_myst/inliner.py
@@ -42,10 +42,11 @@ embedded uri    `uri <a.org>`_
 --------------- --------------- --------------------------------------------------------
 """
 
+from collections.abc import Callable
 import contextlib
 import re
 from re import Match, Pattern
-from typing import Any, Callable
+from typing import Any
 
 from docutils import ApplicationError, nodes
 from docutils.nodes import fully_normalize_name as normalize_name

--- a/rst_to_myst/markdownit.py
+++ b/rst_to_myst/markdownit.py
@@ -2,7 +2,7 @@
 
 from io import StringIO
 from textwrap import indent
-from typing import IO, Any, NamedTuple, Optional
+from typing import IO, Any, NamedTuple
 
 from docutils import nodes
 from markdown_it.token import Token
@@ -21,10 +21,10 @@ class MarkdownItRenderer(nodes.GenericNodeVisitor):
         self,
         document: nodes.document,
         *,
-        warning_stream: Optional[IO] = None,
+        warning_stream: IO | None = None,
         raise_on_warning: bool = False,
         cite_prefix: str = "cite_",
-        default_role: Optional[str] = None,
+        default_role: str | None = None,
         colon_fences: bool = True,
         dollar_math: bool = True,
     ):
@@ -44,7 +44,7 @@ class MarkdownItRenderer(nodes.GenericNodeVisitor):
         # record current state, that can affect children tokens
         self._tokens: list[Token] = []
         self._env = {"references": {}, "duplicate_refs": []}
-        self._inline: Optional[Token] = None
+        self._inline: Token | None = None
         self.parent_tokens: dict[str, int] = {}
         # [(key path, tokens), ...]
         self._front_matter_tokens: list[tuple[list[str], list[Token]]] = []
@@ -54,7 +54,7 @@ class MarkdownItRenderer(nodes.GenericNodeVisitor):
     def document(self) -> nodes.document:
         return self._document
 
-    def warning(self, message: str, line: Optional[int]):
+    def warning(self, message: str, line: int | None):
         if line is not None:
             self._warning_stream.write(f"RENDER WARNING:{line}: {message}\n")
         else:

--- a/rst_to_myst/mdformat_render.py
+++ b/rst_to_myst/mdformat_render.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 import logging
 from textwrap import indent
-from typing import IO, Any, NamedTuple, Optional
+from typing import IO, Any, NamedTuple
 
 from markdown_it.token import Token
 from mdformat.plugins import PARSER_EXTENSIONS
@@ -113,7 +113,7 @@ def from_tokens(
     output: RenderOutput,
     *,
     consecutive_numbering: bool = True,
-    warning_stream: Optional[IO] = None,
+    warning_stream: IO | None = None,
 ) -> str:
     """Convert markdown-it tokens to text."""
     md_renderer = MDRenderer()
@@ -182,13 +182,13 @@ class ConvertedOutput(NamedTuple):
 def rst_to_myst(
     text: str,
     *,
-    warning_stream: Optional[IO] = None,
+    warning_stream: IO | None = None,
     language_code="en",
     use_sphinx: bool = True,
     extensions: Iterable[str] = (),
-    conversions: Optional[dict[str, str]] = None,
+    conversions: dict[str, str] | None = None,
     default_domain: str = "py",
-    default_role: Optional[str] = None,
+    default_role: str | None = None,
     raise_on_warning: bool = False,
     cite_prefix: str = "cite_",
     consecutive_numbering: bool = True,

--- a/rst_to_myst/namespace.py
+++ b/rst_to_myst/namespace.py
@@ -6,7 +6,7 @@ from inspect import getdoc
 from itertools import chain
 import threading
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
 from docutils.parsers.rst import Directive, directives, languages, roles
@@ -34,7 +34,7 @@ class ApplicationNamespace:
     def __init__(
         self,
         language_code: str = "en",
-        default_domain: Optional[str] = "py",
+        default_domain: str | None = "py",
     ):
         self.extensions: dict[str, Extension] = {}
         self.directives: dict[str, Directive] = {}
@@ -43,7 +43,7 @@ class ApplicationNamespace:
         # the default domain will be tried even without the domain prefix
         self.default_domain = default_domain
 
-        self.language_module: Optional[ModuleType] = languages.get_language(
+        self.language_module: ModuleType | None = languages.get_language(
             language_code
         )
 

--- a/rst_to_myst/parser.py
+++ b/rst_to_myst/parser.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 from functools import lru_cache
 from io import StringIO
-from typing import Any, Optional
+from typing import Any
 
 from docutils import nodes
 from docutils.frontend import OptionParser
@@ -141,14 +141,14 @@ def to_docutils_ast(
     uri: str = "source",
     report_level: int = 2,
     halt_level: int = 4,
-    warning_stream: Optional[StringIO] = None,
+    warning_stream: StringIO | None = None,
     language_code: str = "en",
     use_sphinx: bool = True,
     extensions: Iterable[str] = (),
     default_domain: str = "py",
-    conversions: Optional[dict] = None,
+    conversions: dict | None = None,
     front_matter: bool = True,
-    namespace: Optional[ApplicationNamespace] = None,
+    namespace: ApplicationNamespace | None = None,
 ) -> tuple[nodes.document, StringIO]:
     """Convert a string of text to a docutils AST.
 

--- a/rst_to_myst/states.py
+++ b/rst_to_myst/states.py
@@ -1,7 +1,6 @@
 """docutils states."""
 
 import re
-from typing import Optional
 
 from docutils import nodes
 from docutils.nodes import fully_normalize_name as normalize_name
@@ -122,7 +121,7 @@ class ExplicitMixin:
         # directive_class, messages = directives.directive(
         #     type_name, self.memo.language, self.document
         # )
-        directive_class: Optional[Directive] = (
+        directive_class: Directive | None = (
             self.document.settings.namespace.get_directive(type_name)
         )
 


### PR DESCRIPTION
This makes the package compatible with LLVM's current documentation environment without asking LLVM to pin older MyST or markdown-it-py versions. See our markdown migration issue llvm/llvm-project#201242

Perhaps this fixes #77 , the update here sure seems redundant with #90.

Assisted-by: an agent